### PR TITLE
Remove the requirement of 'Parallels Virtualization SDK' for end users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,20 @@
-LDFLAGS=-framework ParallelsVirtualizationSDK
+LDFLAGS=
 PREFIX=.
 
-CPPFLAGS=-g -D_REENTRANT -I./src
+CPPFLAGS=-g -D_REENTRANT -I./src -I/Library/Frameworks/ParallelsVirtualizationSDK.framework/Helpers/SdkWrap -I/Library/Frameworks/ParallelsVirtualizationSDK.framework/Headers -DDYN_API_WRAP=1
 
-prltype: prltype.o common.o
-	gcc $(LDFLAGS) -o $(PREFIX)/bin/prltype out/prltype.o out/common.o
+prltype: prltype.o common.o SdkWrap.o
+	clang++ $(LDFLAGS) -o $(PREFIX)/bin/prltype out/prltype.o out/common.o out/SdkWrap.o
 	chmod 555 $(PREFIX)/bin/prltype
 
 prltype.o: setup
-	gcc $(CPPFLAGS) -c src/prltype.cpp -o out/prltype.o
+	clang++ $(CPPFLAGS) -c src/prltype.cpp -o out/prltype.o
 
 common.o: setup
-	gcc $(CPPFLAGS) -c src/common.cpp -o out/common.o
+	clang++ $(CPPFLAGS) -c src/common.cpp -o out/common.o
+
+SdkWrap.o: setup
+	clang++ $(CPPFLAGS) -c /Library/Frameworks/ParallelsVirtualizationSDK.framework/Helpers/SdkWrap/SdkWrap.cpp -o out/SdkWrap.o
 
 setup:
 	mkdir -p $(PREFIX)/bin

--- a/src/prltype.cpp
+++ b/src/prltype.cpp
@@ -1,3 +1,4 @@
+#include "SdkWrap.h"
 #include "ParallelsVirtualizationSDK/Parallels.h"
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
There is added the usage of `libprl_sdk.5.dylib` from Parallels Desktop bundle and also `SdkWrap.h`.

So, it means that the end user of `prl-utils` will not have to install "Parallels Virtualization SDK" package, it will be required only for compilation.

Thanks to @racktear for help. 

@rickard-von-essen, Is it possible to distribute the pre-built `prl-utils` via homebrew? 
